### PR TITLE
Rework the targets to work on first build.

### DIFF
--- a/FSharp.Android.Resource.targets
+++ b/FSharp.Android.Resource.targets
@@ -10,7 +10,18 @@
         <FSharpAndroidResource_AssemblyFolder>obj/$(Configuration)/</FSharpAndroidResource_AssemblyFolder>
         <FSharpAndroidResource_AssemblyFolder Condition=" '$(TargetFramework)' != '' ">obj/$(Configuration)/$(TargetFramework)/</FSharpAndroidResource_AssemblyFolder>
         <FSharpAndroidResource_AssemblyPath>$(FSharpAndroidResource_AssemblyFolder)$(AssemblyName).Resource.dll</FSharpAndroidResource_AssemblyPath>
+        <FSharpAndroidResource_AssemblyExists Condition=' Exists($(FSharpAndroidResource_AssemblyPath)) '>true</FSharpAndroidResource_AssemblyExists>
+
+        <IsOSX Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' == 'true'">true</IsOSX>
     </PropertyGroup>
+
+    <!-- VS Mac and Rider on Mac don't load dll references for IntelliSense at a late stage -->
+    <!-- So we force it on reload -->
+    <ItemGroup Condition=" '$(FSharpAndroidResource_AssemblyExists)|$(IsOSX)|$(BuildingInsideVisualStudio)' == 'true|true|True' ">
+        <Reference Include="$(FSharpAndroidResource_AssemblyName)">
+            <HintPath>$(FSharpAndroidResource_AssemblyPath)</HintPath>
+        </Reference>
+    </ItemGroup>
 
     <Target
         Name="CompileResourceDesignerForFSharp"
@@ -32,8 +43,8 @@
             UseHostCompilerIfAvailable="true"
             Optimize="$(Optimize)" />
             
-        <!-- Include the resources assembly if generated -->
-        <ItemGroup Condition=" Exists('$(FSharpAndroidResource_AssemblyPath)') ">
+        <!-- Include the resources assembly -->
+        <ItemGroup>
             <ReferencePath Include="$(FSharpAndroidResource_AssemblyPath)">
                 <HintPath>$(FSharpAndroidResource_AssemblyPath)</HintPath>
             </ReferencePath>

--- a/FSharp.Android.Resource.targets
+++ b/FSharp.Android.Resource.targets
@@ -11,13 +11,6 @@
         <FSharpAndroidResource_AssemblyFolder Condition=" '$(TargetFramework)' != '' ">obj/$(Configuration)/$(TargetFramework)/</FSharpAndroidResource_AssemblyFolder>
         <FSharpAndroidResource_AssemblyPath>$(FSharpAndroidResource_AssemblyFolder)$(AssemblyName).Resource.dll</FSharpAndroidResource_AssemblyPath>
     </PropertyGroup>
-    
-    <!-- Include the resources assembly if generated -->
-    <ItemGroup Condition=" Exists($(FSharpAndroidResource_AssemblyPath)) ">
-        <Reference Include="$(FSharpAndroidResource_AssemblyName)">
-            <HintPath>$(FSharpAndroidResource_AssemblyPath)</HintPath>
-        </Reference>
-    </ItemGroup>
 
     <Target
         Name="CompileResourceDesignerForFSharp"
@@ -39,5 +32,12 @@
             UseHostCompilerIfAvailable="true"
             Optimize="$(Optimize)" />
             
+        <!-- Include the resources assembly if generated -->
+        <ItemGroup Condition=" Exists('$(FSharpAndroidResource_AssemblyPath)') ">
+            <ReferencePath Include="$(FSharpAndroidResource_AssemblyPath)">
+                <HintPath>$(FSharpAndroidResource_AssemblyPath)</HintPath>
+            </ReferencePath>
+            <FileWrites Include="$(FSharpAndroidResource_AssemblyPath)" />
+        </ItemGroup>
     </Target>
 </Project>

--- a/README.md
+++ b/README.md
@@ -19,6 +19,5 @@ MSBuild task to expose resources to F# .NET Fx / .NET 6 Android projects
 </PropertyGroup>
 ```
 
-3. Compile 2 times (first time will fail because FSharp.Android.Resource needs to generate the dll first)
-4. If you're in an IDE, close/reopen either the Android project or the whole solution
-5. Everything should be working, enjoy!
+3. (macOS only) If you're in an IDE and you see errors, unload/reload the Android project
+4. Everything should be working, enjoy!

--- a/tests/App.Android.NetFX/App.Android.NetFX.fsproj
+++ b/tests/App.Android.NetFX/App.Android.NetFX.fsproj
@@ -14,7 +14,7 @@
     <AndroidApplication>True</AndroidApplication>
     <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
     <AndroidResgenClass>Resource</AndroidResgenClass>
-    <AndroidManifest></AndroidManifest>
+    <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
     <JavaMaximumHeapSize></JavaMaximumHeapSize>


### PR DESCRIPTION
This is a great solution, however with a few minor changes it will be
even better :).

If we move the `ItemGroup` inside the `Target` and after the call to
`Csc` it will add the assembly after it has been compiled. The good
thing is that even if the `Target` is skipped, msbuild will still
evaluate the `ItemGroup`. This means the assembly will always get added.

Because we are doing the `ItemGroup` changes late in the compilation process
we should use the `ReferencePath` rather than `References` `ItemGroup`.
This will make sure it gets passed tot the fsharp compiler.

One last change is to add the assembly to the `FileWrites` group. This
will prevent it from being deleted between builds.