### PR TITLE
Disable late import when building inside VS/Rider on macOS

### DIFF
--- a/FSharp.Android.Resource.proj
+++ b/FSharp.Android.Resource.proj
@@ -12,7 +12,7 @@
         <IncludeBuildOutput>false</IncludeBuildOutput>
         <!-- https://github.com/dotnet/templating/issues/2350#issuecomment-610431461 -->
         <NoDefaultExcludes>true</NoDefaultExcludes>
-        <VersionPrefix>1.0.1</VersionPrefix>
+        <VersionPrefix>1.0.2</VersionPrefix>
         <TargetFramework>netstandard2.0</TargetFramework>
         <NoWarn>$(NoWarn);NU5128</NoWarn>
     </PropertyGroup>

--- a/FSharp.Android.Resource.sln
+++ b/FSharp.Android.Resource.sln
@@ -12,6 +12,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "FSharp.Android.Resource", "FSharp.Android.Resource", "{65769B5A-A981-468D-9075-1FFC982D9050}"
 	ProjectSection(SolutionItems) = preProject
 		FSharp.Android.Resource.targets = FSharp.Android.Resource.targets
+		FSharp.Android.Resource.proj = FSharp.Android.Resource.proj
 	EndProjectSection
 EndProject
 Global

--- a/FSharp.Android.Resource.targets
+++ b/FSharp.Android.Resource.targets
@@ -44,7 +44,7 @@
             Optimize="$(Optimize)" />
             
         <!-- Include the resources assembly -->
-        <ItemGroup>
+        <ItemGroup Condition=" '$(FSharpAndroidResource_AssemblyExists)|$(IsOSX)|$(BuildingInsideVisualStudio)' != 'true|true|True' ">
             <ReferencePath Include="$(FSharpAndroidResource_AssemblyPath)">
                 <HintPath>$(FSharpAndroidResource_AssemblyPath)</HintPath>
             </ReferencePath>

--- a/FSharp.Android.Resource.targets
+++ b/FSharp.Android.Resource.targets
@@ -13,12 +13,12 @@
         <FSharpAndroidResource_AssemblyExists Condition=' Exists($(FSharpAndroidResource_AssemblyPath)) '>true</FSharpAndroidResource_AssemblyExists>
 
         <IsOSX Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' == 'true'">true</IsOSX>
-        <FSharpAndroidResource_ForceLoadReference Condition=" '$(FSharpAndroidResource_AssemblyExists)|$(IsOSX)|$(BuildingInsideVisualStudio)' == 'true|true|True' ">true</FSharpAndroidResource_ForceLoadReference>
+        <FSharpAndroidResource_ForceLoadReference Condition=" '$(IsOSX)|$(BuildingInsideVisualStudio)' == 'true|True' ">true</FSharpAndroidResource_ForceLoadReference>
     </PropertyGroup>
 
     <!-- VS Mac and Rider on Mac don't load dll references for IntelliSense at a late stage -->
     <!-- So we force it on reload -->
-    <ItemGroup Condition=" '$(FSharpAndroidResource_ForceLoadReference)' == 'true' ">
+    <ItemGroup Condition=" '$(FSharpAndroidResource_AssemblyExists)' == 'true' AND '$(FSharpAndroidResource_ForceLoadReference)' == 'true' ">
         <Reference Include="$(FSharpAndroidResource_AssemblyName)">
             <HintPath>$(FSharpAndroidResource_AssemblyPath)</HintPath>
         </Reference>

--- a/FSharp.Android.Resource.targets
+++ b/FSharp.Android.Resource.targets
@@ -13,11 +13,12 @@
         <FSharpAndroidResource_AssemblyExists Condition=' Exists($(FSharpAndroidResource_AssemblyPath)) '>true</FSharpAndroidResource_AssemblyExists>
 
         <IsOSX Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' == 'true'">true</IsOSX>
+        <FSharpAndroidResource_ForceLoadReference Condition=" '$(FSharpAndroidResource_AssemblyExists)|$(IsOSX)|$(BuildingInsideVisualStudio)' == 'true|true|True' ">true</FSharpAndroidResource_ForceLoadReference>
     </PropertyGroup>
 
     <!-- VS Mac and Rider on Mac don't load dll references for IntelliSense at a late stage -->
     <!-- So we force it on reload -->
-    <ItemGroup Condition=" '$(FSharpAndroidResource_AssemblyExists)|$(IsOSX)|$(BuildingInsideVisualStudio)' == 'true|true|True' ">
+    <ItemGroup Condition=" '$(FSharpAndroidResource_ForceLoadReference)' == 'true' ">
         <Reference Include="$(FSharpAndroidResource_AssemblyName)">
             <HintPath>$(FSharpAndroidResource_AssemblyPath)</HintPath>
         </Reference>
@@ -26,7 +27,7 @@
     <Target
         Name="CompileResourceDesignerForFSharp"
         BeforeTargets="CoreCompile"
-        DependsOnTargets="ResolveProjectReferences;ResolveAssemblyReferences"
+        DependsOnTargets="ResolveProjectReferences;ResolveAssemblyReferences;UpdateAndroidResources"
         Inputs="$(AndroidResgenFile)"
         Outputs="$(FSharpAndroidResource_AssemblyPath)">
 
@@ -44,7 +45,7 @@
             Optimize="$(Optimize)" />
             
         <!-- Include the resources assembly -->
-        <ItemGroup Condition=" '$(FSharpAndroidResource_AssemblyExists)|$(IsOSX)|$(BuildingInsideVisualStudio)' != 'true|true|True' ">
+        <ItemGroup Condition=" '$(FSharpAndroidResource_ForceLoadReference)' != 'true' ">
             <ReferencePath Include="$(FSharpAndroidResource_AssemblyPath)">
                 <HintPath>$(FSharpAndroidResource_AssemblyPath)</HintPath>
             </ReferencePath>


### PR DESCRIPTION
There seems to be a bug in MSBuild on macOS at design-time preventing from importing a generated assembly at later time in the build process.
https://github.com/fabulousfx/FSharp.Android.Resource/pull/2#issuecomment-1068950823

To avoid this, we already try to import the dll file early if it exists but this was leading to a build error when we tried to access a method in the dll.

```
/Library/Frameworks/Mono.framework/External/xbuild/Xamarin/Android/Xamarin.Android.Legacy.targets(328,5):
Error XA2002 : Can not resolve reference: MyProject.Resource, referenced by MyProject.
Please add a NuGet package or assembly reference for MyProject.Resource, or remove the reference to MyProject.
```

A fix for this is to completely disable late import on macOS when building inside IDEs.
When building from command line (dotnet/msbuild), it will still work on 1st build but in IDEs 2 builds will be required.