### PR TITLE
Make sure resources are correct at runtime

### DIFF
--- a/FSharp.Android.Resource.proj
+++ b/FSharp.Android.Resource.proj
@@ -12,7 +12,7 @@
         <IncludeBuildOutput>false</IncludeBuildOutput>
         <!-- https://github.com/dotnet/templating/issues/2350#issuecomment-610431461 -->
         <NoDefaultExcludes>true</NoDefaultExcludes>
-        <VersionPrefix>1.0.2</VersionPrefix>
+        <VersionPrefix>1.0.3</VersionPrefix>
         <TargetFramework>netstandard2.0</TargetFramework>
         <NoWarn>$(NoWarn);NU5128</NoWarn>
     </PropertyGroup>

--- a/FSharp.Android.Resource.sln
+++ b/FSharp.Android.Resource.sln
@@ -15,6 +15,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "FSharp.Android.Resource", "
 		FSharp.Android.Resource.proj = FSharp.Android.Resource.proj
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "_Solution Items", "_Solution Items", "{BF543C6C-6B11-4B34-8ACC-0C811B784607}"
+	ProjectSection(SolutionItems) = preProject
+		README.md = README.md
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/FSharp.Android.Resource.targets
+++ b/FSharp.Android.Resource.targets
@@ -11,14 +11,9 @@
         <FSharpAndroidResource_AssemblyFolder Condition=" '$(TargetFramework)' != '' ">obj/$(Configuration)/$(TargetFramework)/</FSharpAndroidResource_AssemblyFolder>
         <FSharpAndroidResource_AssemblyPath>$(FSharpAndroidResource_AssemblyFolder)$(AssemblyName).Resource.dll</FSharpAndroidResource_AssemblyPath>
         <FSharpAndroidResource_AssemblyExists Condition=' Exists($(FSharpAndroidResource_AssemblyPath)) '>true</FSharpAndroidResource_AssemblyExists>
-
-        <IsOSX Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' == 'true'">true</IsOSX>
-        <FSharpAndroidResource_ForceLoadReference Condition=" '$(IsOSX)|$(BuildingInsideVisualStudio)' == 'true|True' ">true</FSharpAndroidResource_ForceLoadReference>
     </PropertyGroup>
 
-    <!-- VS Mac and Rider on Mac don't load dll references for IntelliSense at a late stage -->
-    <!-- So we force it on reload -->
-    <ItemGroup Condition=" '$(FSharpAndroidResource_AssemblyExists)' == 'true' AND '$(FSharpAndroidResource_ForceLoadReference)' == 'true' ">
+    <ItemGroup Condition=" '$(FSharpAndroidResource_AssemblyExists)' == 'true' ">
         <Reference Include="$(FSharpAndroidResource_AssemblyName)">
             <HintPath>$(FSharpAndroidResource_AssemblyPath)</HintPath>
         </Reference>
@@ -43,13 +38,5 @@
             TargetType="library"
             UseHostCompilerIfAvailable="true"
             Optimize="$(Optimize)" />
-            
-        <!-- Include the resources assembly -->
-        <ItemGroup Condition=" '$(FSharpAndroidResource_ForceLoadReference)' != 'true' ">
-            <ReferencePath Include="$(FSharpAndroidResource_AssemblyPath)">
-                <HintPath>$(FSharpAndroidResource_AssemblyPath)</HintPath>
-            </ReferencePath>
-            <FileWrites Include="$(FSharpAndroidResource_AssemblyPath)" />
-        </ItemGroup>
     </Target>
 </Project>

--- a/README.md
+++ b/README.md
@@ -5,13 +5,17 @@ MSBuild task to expose resources to F# .NET Fx / .NET 6 Android projects
 
 ### How to use
 
-1. Replace the old type provider with the new package in your Android project
+1. Replace the old type provider with the new package for your Android project
+
 ```diff
 - <PackageReference Include="Xamarin.Android.FSharp.ResourceProvider" />
 + <PackageReference Include="FSharp.Android.Resource" />
 ```
 
-2. Remove old properties from the Android fsproj
+2. Remove the following properties from your Android project fsproj file. 
+   They are managed by FSharp.Android.Resource
+   
+
 ```diff
 <PropertyGroup>
 -   <AndroidResgenFile>Resources/Resource.designer.cs</AndroidResgenFile>
@@ -19,5 +23,35 @@ MSBuild task to expose resources to F# .NET Fx / .NET 6 Android projects
 </PropertyGroup>
 ```
 
-3. (macOS only) If you're in an IDE and you see errors, unload/reload the Android project
-4. Everything should be working, enjoy!
+3. Run the build one time; **it will fail but it's ok**. This generates the resource assembly.
+4. Reload your project to be able to see the new resource assembly
+5. Add `do Resource.UpdateIdValues()` to your MainActivity (or whichever activity is the first one to display)
+
+```fsharp
+type MainActivity() =
+    inherit Activity()
+    
+    // This is required for the app to pick up the right resources
+    do Resource.UpdateIdValues()
+    
+    member _.OnCreate(bundle) =
+      base.OnCreate(bundle)
+      
+      // Now you can use Resource like usual
+      this.SetContentView(Resource.Layout.Main)
+```
+
+6. Build one more time. This time it should complete successfully.
+7. Everything should be working, enjoy!
+
+### How to use in a Continuous Integration environment
+
+Given the first build will always fail, you can use the following steps to workaround it:
+
+1. Execute a build using the target `CompileResourceDesignerForFSharp`
+2. Execute a normal build
+
+```sh
+msbuild -t:CompileResourceDesignerForFSharp
+msbuild -t:Build
+```

--- a/tests/App.Android.Net6/MainActivity.fs
+++ b/tests/App.Android.Net6/MainActivity.fs
@@ -9,12 +9,13 @@ open Android.Runtime
 open Android.Views
 open Android.Widget
 
-
 [<Activity (Label = "App.Android.Net6", MainLauncher = true, Icon = "@mipmap/icon")>]
 type MainActivity () =
     inherit Activity ()
 
     let mutable count:int = 1
+
+    do Resource.UpdateIdValues()
 
     override this.OnCreate (bundle) =
 

--- a/tests/App.Android.NetFX/App.Android.NetFX.fsproj
+++ b/tests/App.Android.NetFX/App.Android.NetFX.fsproj
@@ -28,8 +28,10 @@
     <AndroidLinkMode>None</AndroidLinkMode>
     <PlatformTarget></PlatformTarget>
     <JavaMaximumHeapSize></JavaMaximumHeapSize>
-    <AndroidUseAapt2>false</AndroidUseAapt2>
+    <AndroidUseAapt2>true</AndroidUseAapt2>
     <AndroidManifest></AndroidManifest>
+    <AndroidSupportedAbis>armeabi-v7a;x86;arm64-v8a;x86_64</AndroidSupportedAbis>
+    <AndroidUseSharedRuntime>true</AndroidUseSharedRuntime>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -45,11 +47,12 @@
     <AndroidManifest></AndroidManifest>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FSharp.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <HintPath>..\..\packages\FSharp.Core.6.0.1\lib\netstandard2.1\FSharp.Core.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="FSharp.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\FSharp.Core.6.0.4\lib\netstandard2.1\FSharp.Core.dll</HintPath>
     </Reference>
+    <Reference Include="Java.Interop" />
     <Reference Include="System" />
+    <Reference Include="System.Numerics.Vectors" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Core" />
     <Reference Include="System.Numerics" />

--- a/tests/App.Android.NetFX/MainActivity.fs
+++ b/tests/App.Android.NetFX/MainActivity.fs
@@ -1,12 +1,6 @@
 ﻿namespace App.Android.NetFX
 
-open System
-
 open Android.App
-open Android.Content
-open Android.OS
-open Android.Runtime
-open Android.Views
 open Android.Widget
 
 [<Activity (Label = "App.Android.NetFX", MainLauncher = true, Icon = "@mipmap/icon")>]
@@ -15,17 +9,17 @@ type MainActivity () =
 
     let mutable count:int = 1
 
-    override this.OnCreate (bundle) =
+    do Resource.UpdateIdValues()
 
-        base.OnCreate (bundle)
+    override this.OnCreate(bundle) =
+        base.OnCreate(bundle)
 
         // Set our view from the "main" layout resource
-        this.SetContentView (Resources.Layout.Main)
+        this.SetContentView(Resource.Layout.Main)
 
         // Get our button from the layout resource, and attach an event to it
-        let button = this.FindViewById<Button>(Resources.Id.myButton)
+        let button = this.FindViewById<Button>(Resource.Id.myButton)
         button.Click.Add (fun args -> 
             button.Text <- sprintf "%d clicks! NETFX" count
             count <- count + 1
         )
-

--- a/tests/App.Android.NetFX/Properties/AndroidManifest.xml
+++ b/tests/App.Android.NetFX/Properties/AndroidManifest.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="App.Android.NetFX">
-	<uses-sdk />
+	<uses-sdk android:minSdkVersion="21" android:targetSdkVersion="31" />
 	<application android:label="App.Android.NetFX"></application>
 </manifest>

--- a/tests/App.Android.NetFX/Properties/AssemblyInfo.fs
+++ b/tests/App.Android.NetFX/Properties/AssemblyInfo.fs
@@ -4,10 +4,6 @@ open System.Reflection
 open System.Runtime.CompilerServices
 open Android.App
 
-// the name of the type here needs to match the name inside the ResourceDesigner attribute
-type Resources = App.Android.NetFX.Resource
-[<assembly: Android.Runtime.ResourceDesigner("App.Android.NetFX.Resources", IsApplication=true)>]
-
 // Information about this assembly is defined by the following attributes. 
 // Change them to the values specific to your project.
 

--- a/tests/App.Android.NetFX/packages.config
+++ b/tests/App.Android.NetFX/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FSharp.Core" version="6.0.1" targetFramework="monoandroid12.0" />
+  <package id="FSharp.Core" version="6.0.4" targetFramework="monoandroid12.0" />
 </packages>


### PR DESCRIPTION
@dellis1972 I had to revert your changes. Somehow using `ReferencePath` was making the build fail with this weird error:

```
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Xamarin\Android\Xamarin.Android.Legacy.targets(315,5): Error XA2002: Can not resolve reference: `MyProject.Resource`, referenced by `MyProject`. Please add a NuGet package or assembly reference for `MyProject.Resource`, or remove the reference to `MyProject`.
```

This only happens if we directly call `Resource.UpdateIdValues()`.

Curiously, this call to `UpdateIdValues()` is required even though it's supposed to be called during the static constructor of `Resource.designer.cs`. Otherwise the resources don't have the right ids.